### PR TITLE
remove chunked_transfer_encoding settings

### DIFF
--- a/config/nginx/include/proxy.conf
+++ b/config/nginx/include/proxy.conf
@@ -5,7 +5,6 @@ proxy_set_header Host $http_host;
 
 proxy_connect_timeout 300;
 proxy_http_version 1.1;
-chunked_transfer_encoding off;
 
 proxy_set_header Upgrade $http_upgrade;
 proxy_set_header Connection "upgrade";


### PR DESCRIPTION
to avoid request hanging with http proxy(set with [Dreamacro/clash](https://github.com/Dreamacro/clash))

`chunked_transfer_encoding off;` 会导致设置了代理(使用 [Dreamacro/clash](https://github.com/Dreamacro/clash))的情况下，资源请求卡住。
